### PR TITLE
Temporarily downgrade Vernier required_ruby_version

### DIFF
--- a/vernier.gemspec
+++ b/vernier.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary
   spec.homepage = "https://github.com/jhawthorn/vernier"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.1"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Downgraded to work around https://github.com/dependabot/dependabot-core/issues/9051